### PR TITLE
Add macOS SwiftUI StoryMaker app skeleton

### DIFF
--- a/StoryMakerApp/StoryMakerApp.xcodeproj/project.pbxproj
+++ b/StoryMakerApp/StoryMakerApp.xcodeproj/project.pbxproj
@@ -1,0 +1,213 @@
+// !$*UTF8*$!
+{
+archiveVersion = 1;
+classes = {
+};
+objectVersion = 55;
+objects = {
+
+/* Begin PBXBuildFile section */
+38EE0C2AA0534CBE95876B9B /* StoryMakerAppApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = F355F8182F26478EB0E24B08 /* StoryMakerAppApp.swift */; };
+45DD24F77170431BBBF326D8 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 826B8D3B4F2D4AD69474E07E /* ContentView.swift */; };
+37E7CBEBD0C14D6791F7A58E /* DashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53FFDFD280C54A96ADCC8114 /* DashboardView.swift */; };
+FDC3F7DCFA2B4E698957A431 /* StoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D778EAF973E24673AB267170 /* StoryView.swift */; };
+FD5875BF76BD4A04AE1D78F8 /* ImagesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7C4CE93260D4F709CD8FBC4 /* ImagesView.swift */; };
+A34A5F1D44794FE99D9C952D /* TTSView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 077393AF68F14BE08973D0D8 /* TTSView.swift */; };
+60771942AAC44E0BAE42C16E /* AssembleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E0BD2E75AAC4CDDBE05E183 /* AssembleView.swift */; };
+026DC806A59A4D8597070E56 /* PublishView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30673014A23B40A98ABC58D5 /* PublishView.swift */; };
+D90E2AE87804414AA70A3823 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 223BE763922744D6BCD009B7 /* SettingsView.swift */; };
+DADF52293D984416B7CFB0A4 /* AppCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2634F9BB465D47F0AD515AFD /* AppCommands.swift */; };
+89A1FEB8024B45C2B0F7F8B8 /* Job.swift in Sources */ = {isa = PBXBuildFile; fileRef = F060C42E85F04ECE8753D99B /* Job.swift */; };
+1AEE527BF6BB4248ADD2791A /* JobQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C710128E4254C0FA16AC37A /* JobQueue.swift */; };
+8F1E9C8E306F48CB8A8B4764 /* SettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF9092F09F844E1895EB40EA /* SettingsStore.swift */; };
+4DF3F0DDA29E4AB6A46EDB1F /* KeychainHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62373CA32E3940A79C1E691A /* KeychainHelper.swift */; };
+FFBA3B458924471F89BC3F33 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4E7F77AECEDD4EB9A2D6DC60 /* Assets.xcassets */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+F355F8182F26478EB0E24B08 /* StoryMakerAppApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoryMakerAppApp.swift; sourceTree = "<group>"; };
+826B8D3B4F2D4AD69474E07E /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+53FFDFD280C54A96ADCC8114 /* DashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardView.swift; sourceTree = "<group>"; };
+D778EAF973E24673AB267170 /* StoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoryView.swift; sourceTree = "<group>"; };
+D7C4CE93260D4F709CD8FBC4 /* ImagesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagesView.swift; sourceTree = "<group>"; };
+077393AF68F14BE08973D0D8 /* TTSView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TTSView.swift; sourceTree = "<group>"; };
+9E0BD2E75AAC4CDDBE05E183 /* AssembleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssembleView.swift; sourceTree = "<group>"; };
+30673014A23B40A98ABC58D5 /* PublishView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublishView.swift; sourceTree = "<group>"; };
+223BE763922744D6BCD009B7 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
+2634F9BB465D47F0AD515AFD /* AppCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCommands.swift; sourceTree = "<group>"; };
+F060C42E85F04ECE8753D99B /* Job.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models/Job.swift; sourceTree = "<group>"; };
+6C710128E4254C0FA16AC37A /* JobQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models/JobQueue.swift; sourceTree = "<group>"; };
+DF9092F09F844E1895EB40EA /* SettingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models/SettingsStore.swift; sourceTree = "<group>"; };
+62373CA32E3940A79C1E691A /* KeychainHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models/KeychainHelper.swift; sourceTree = "<group>"; };
+8FA1A7FE4BF548E6BEF5FDE9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+4E7F77AECEDD4EB9A2D6DC60 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+04F6E3377B78495AB2503509 /* StoryMakerApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; path = StoryMakerApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXGroup section */
+C89C3DA584134AD8974375C5 = {
+isa = PBXGroup;
+children = (
+9E417217686745429A4F5C06 /* StoryMakerApp */,
+D5B029D9C333408AB986DCF1 /* Products */,
+);
+sourceTree = "<group>";
+};
+9E417217686745429A4F5C06 /* StoryMakerApp */ = {
+isa = PBXGroup;
+children = (
+F355F8182F26478EB0E24B08 /* StoryMakerAppApp.swift */,
+826B8D3B4F2D4AD69474E07E /* ContentView.swift */,
+53FFDFD280C54A96ADCC8114 /* DashboardView.swift */,
+D778EAF973E24673AB267170 /* StoryView.swift */,
+D7C4CE93260D4F709CD8FBC4 /* ImagesView.swift */,
+077393AF68F14BE08973D0D8 /* TTSView.swift */,
+9E0BD2E75AAC4CDDBE05E183 /* AssembleView.swift */,
+30673014A23B40A98ABC58D5 /* PublishView.swift */,
+223BE763922744D6BCD009B7 /* SettingsView.swift */,
+2634F9BB465D47F0AD515AFD /* AppCommands.swift */,
+4E7F77AECEDD4EB9A2D6DC60 /* Assets.xcassets */,
+8FA1A7FE4BF548E6BEF5FDE9 /* Info.plist */,
+E8D3C345D44F47F5B7EC972F /* Models */,
+);
+path = StoryMakerApp;
+sourceTree = "<group>";
+};
+E8D3C345D44F47F5B7EC972F /* Models */ = {
+isa = PBXGroup;
+children = (
+F060C42E85F04ECE8753D99B /* Job.swift */,
+6C710128E4254C0FA16AC37A /* JobQueue.swift */,
+DF9092F09F844E1895EB40EA /* SettingsStore.swift */,
+62373CA32E3940A79C1E691A /* KeychainHelper.swift */,
+);
+path = Models;
+sourceTree = "<group>";
+};
+D5B029D9C333408AB986DCF1 /* Products */ = {
+isa = PBXGroup;
+children = (
+04F6E3377B78495AB2503509 /* StoryMakerApp.app */,
+);
+name = Products;
+sourceTree = "<group>";
+};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+EBCCF27961534591BD762AC2 /* StoryMakerApp */ = {
+isa = PBXNativeTarget;
+buildConfigurationList = E47EDC055EFF4338AC49459E /* Build configuration list for PBXNativeTarget "StoryMakerApp" */;
+buildPhases = (
+2E1C12D7463A4615B70AD599 /* Sources */,
+DA7A5CEA75774DC8A047BBF2 /* Frameworks */,
+000B5A98D4A9473BA3ADC87B /* Resources */,
+);
+buildRules = (
+);
+dependencies = (
+);
+name = StoryMakerApp;
+productName = StoryMakerApp;
+productReference = 04F6E3377B78495AB2503509 /* StoryMakerApp.app */;
+productType = "com.apple.product-type.application";
+};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+576A409AC6074097A3FB520E /* Project object */ = {
+isa = PBXProject;
+attributes = {
+LastSwiftUpdateCheck = 1320;
+LastUpgradeCheck = 1320;
+};
+buildConfigurationList = E47EDC055EFF4338AC49459E /* Build configuration list for PBXNativeTarget "StoryMakerApp" */;
+compatibilityVersion = "Xcode 13.0";
+developmentRegion = en;
+hasScannedForEncodings = 0;
+mainGroup = C89C3DA584134AD8974375C5;
+productRefGroup = D5B029D9C333408AB986DCF1 /* Products */;
+targets = (
+EBCCF27961534591BD762AC2 /* StoryMakerApp */,
+);
+};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+000B5A98D4A9473BA3ADC87B /* Resources */ = {
+isa = PBXResourcesBuildPhase;
+buildActionMask = 2147483647;
+files = (
+FFBA3B458924471F89BC3F33 /* Assets.xcassets in Resources */,
+);
+runOnlyForDeploymentPostprocessing = 0;
+};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+2E1C12D7463A4615B70AD599 /* Sources */ = {
+isa = PBXSourcesBuildPhase;
+buildActionMask = 2147483647;
+files = (
+38EE0C2AA0534CBE95876B9B /* StoryMakerAppApp.swift in Sources */,
+45DD24F77170431BBBF326D8 /* ContentView.swift in Sources */,
+37E7CBEBD0C14D6791F7A58E /* DashboardView.swift in Sources */,
+FDC3F7DCFA2B4E698957A431 /* StoryView.swift in Sources */,
+FD5875BF76BD4A04AE1D78F8 /* ImagesView.swift in Sources */,
+A34A5F1D44794FE99D9C952D /* TTSView.swift in Sources */,
+60771942AAC44E0BAE42C16E /* AssembleView.swift in Sources */,
+026DC806A59A4D8597070E56 /* PublishView.swift in Sources */,
+D90E2AE87804414AA70A3823 /* SettingsView.swift in Sources */,
+DADF52293D984416B7CFB0A4 /* AppCommands.swift in Sources */,
+89A1FEB8024B45C2B0F7F8B8 /* Job.swift in Sources */,
+1AEE527BF6BB4248ADD2791A /* JobQueue.swift in Sources */,
+8F1E9C8E306F48CB8A8B4764 /* SettingsStore.swift in Sources */,
+4DF3F0DDA29E4AB6A46EDB1F /* KeychainHelper.swift in Sources */,
+);
+runOnlyForDeploymentPostprocessing = 0;
+};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+1B955008F166476896004B0B /* Debug */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+CODE_SIGN_STYLE = Automatic;
+DEVELOPMENT_TEAM = "";
+INFOPLIST_FILE = StoryMakerApp/Info.plist;
+MACOSX_DEPLOYMENT_TARGET = 12.0;
+PRODUCT_BUNDLE_IDENTIFIER = com.example.StoryMakerApp;
+PRODUCT_NAME = "$(TARGET_NAME)";
+SWIFT_VERSION = 5.0;
+};
+name = Debug;
+};
+E5C19D3B9FEA433D8DB3EFE4 /* Release */ = {
+isa = XCBuildConfiguration;
+buildSettings = {
+CODE_SIGN_STYLE = Automatic;
+DEVELOPMENT_TEAM = "";
+INFOPLIST_FILE = StoryMakerApp/Info.plist;
+MACOSX_DEPLOYMENT_TARGET = 12.0;
+PRODUCT_BUNDLE_IDENTIFIER = com.example.StoryMakerApp;
+PRODUCT_NAME = "$(TARGET_NAME)";
+SWIFT_VERSION = 5.0;
+};
+name = Release;
+};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+E47EDC055EFF4338AC49459E /* Build configuration list for PBXNativeTarget "StoryMakerApp" */ = {
+isa = XCConfigurationList;
+buildConfigurations = (
+1B955008F166476896004B0B /* Debug */,
+E5C19D3B9FEA433D8DB3EFE4 /* Release */,
+);
+defaultConfigurationIsVisible = 0;
+defaultConfigurationName = Release;
+};
+/* End XCConfigurationList section */
+};
+rootObject = 576A409AC6074097A3FB520E /* Project object */;
+}

--- a/StoryMakerApp/StoryMakerApp/AppCommands.swift
+++ b/StoryMakerApp/StoryMakerApp/AppCommands.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+struct AppCommands: Commands {
+    @ObservedObject var jobQueue: JobQueue
+
+    var body: some Commands {
+        CommandMenu("File") {
+            Button("New Story") { jobQueue.add(Job(type: .story)) }
+            Button("Run") { jobQueue.add(Job(type: .render)) }
+            Button("Open Releases") { jobQueue.openReleasesFolder() }
+        }
+    }
+}

--- a/StoryMakerApp/StoryMakerApp/AssembleView.swift
+++ b/StoryMakerApp/StoryMakerApp/AssembleView.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+struct AssembleView: View {
+    @State private var fps: Int = 30
+    @State private var autoDuration: Bool = true
+    @State private var fixedDuration: Double = 5
+
+    var body: some View {
+        Form {
+            Stepper("FPS: \(fps)", value: $fps, in: 1...120)
+            Toggle("Auto duration per image", isOn: $autoDuration)
+            if !autoDuration {
+                HStack {
+                    Text("Fixed duration (s)")
+                    TextField("", value: $fixedDuration, formatter: NumberFormatter())
+                }
+            }
+            Button("Assemble Video", action: assemble)
+        }
+        .padding()
+    }
+
+    func assemble() {
+        // Placeholder for video assembly
+        let outDir = URL(fileURLWithPath: "out", relativeTo: URL(fileURLWithPath: FileManager.default.currentDirectoryPath))
+        try? FileManager.default.createDirectory(at: outDir, withIntermediateDirectories: true)
+    }
+}

--- a/StoryMakerApp/StoryMakerApp/Assets.xcassets/Contents.json
+++ b/StoryMakerApp/StoryMakerApp/Assets.xcassets/Contents.json
@@ -1,0 +1,3 @@
+{
+  "info" : { "version" : 1, "author" : "xcode" }
+}

--- a/StoryMakerApp/StoryMakerApp/ContentView.swift
+++ b/StoryMakerApp/StoryMakerApp/ContentView.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        TabView {
+            DashboardView()
+                .tabItem { Label("Dashboard", systemImage: "square.grid.2x2") }
+            StoryView()
+                .tabItem { Label("Story", systemImage: "text.book.closed") }
+            ImagesView()
+                .tabItem { Label("Images", systemImage: "photo") }
+            TTSView()
+                .tabItem { Label("TTS", systemImage: "waveform") }
+            AssembleView()
+                .tabItem { Label("Assemble", systemImage: "film") }
+            PublishView()
+                .tabItem { Label("Publish", systemImage: "paperplane") }
+            SettingsView()
+                .tabItem { Label("Settings", systemImage: "gear") }
+        }
+        .frame(minWidth: 800, minHeight: 600)
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/StoryMakerApp/StoryMakerApp/DashboardView.swift
+++ b/StoryMakerApp/StoryMakerApp/DashboardView.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+struct DashboardView: View {
+    @EnvironmentObject var jobQueue: JobQueue
+    @State private var selectedJob: Job?
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            Table(jobQueue.jobs, selection: $selectedJob) {
+                TableColumn("ID") { job in
+                    Text(job.id.uuidString.prefix(8))
+                }
+                TableColumn("Status") { job in
+                    Text(job.status.rawValue)
+                }
+                TableColumn("Progress") { job in
+                    Text("\(Int(job.progress * 100))%")
+                }
+            }
+            HStack {
+                Button("New Story") { jobQueue.add(Job(type: .story)) }
+                Button("Render") { jobQueue.add(Job(type: .render)) }
+                Button("Publish") { jobQueue.add(Job(type: .publish)) }
+                Button("Open Folder") { jobQueue.openReleasesFolder() }
+            }
+            .padding(.vertical)
+            if let job = selectedJob ?? jobQueue.jobs.last {
+                ScrollView {
+                    ForEach(job.logs.suffix(20), id: \.self) { line in
+                        Text(line)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .font(.system(.body, design: .monospaced))
+                    }
+                }
+            }
+        }
+        .padding()
+    }
+}

--- a/StoryMakerApp/StoryMakerApp/ImagesView.swift
+++ b/StoryMakerApp/StoryMakerApp/ImagesView.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+struct ImagesView: View {
+    @State private var template: String = ""
+    @State private var crop169: Bool = true
+
+    var body: some View {
+        Form {
+            TextEditor(text: $template)
+                .frame(minHeight: 100)
+                .border(Color.gray)
+                .padding(.bottom)
+            HStack {
+                Text("Resolution: 1920x1080")
+                Spacer()
+                Toggle("Crop to 16:9 after generation", isOn: $crop169)
+            }
+            Button("Render Images", action: renderImages)
+        }
+        .padding()
+    }
+
+    func renderImages() {
+        // Placeholder for rendering images based on scenes
+    }
+}

--- a/StoryMakerApp/StoryMakerApp/Info.plist
+++ b/StoryMakerApp/StoryMakerApp/Info.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleName</key>
+  <string>$(PRODUCT_NAME)</string>
+  <key>CFBundleVersion</key>
+  <string>1</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>LSMinimumSystemVersion</key>
+  <string>12.0</string>
+</dict>
+</plist>

--- a/StoryMakerApp/StoryMakerApp/Models/Job.swift
+++ b/StoryMakerApp/StoryMakerApp/Models/Job.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+enum JobType: String, Codable {
+    case story
+    case render
+    case publish
+    case tts
+    case assemble
+}
+
+enum JobStatus: String, Codable {
+    case pending
+    case running
+    case done
+    case error
+}
+
+struct Job: Identifiable, Codable {
+    var id = UUID()
+    var type: JobType
+    var status: JobStatus = .pending
+    var progress: Double = 0.0
+    var logs: [String] = []
+}

--- a/StoryMakerApp/StoryMakerApp/Models/JobQueue.swift
+++ b/StoryMakerApp/StoryMakerApp/Models/JobQueue.swift
@@ -1,0 +1,27 @@
+import Foundation
+import SwiftUI
+
+class JobQueue: ObservableObject {
+    @Published var jobs: [Job] = []
+
+    func add(_ job: Job) {
+        jobs.append(job)
+    }
+
+    func update(id: UUID, status: JobStatus? = nil, progress: Double? = nil, log: String? = nil) {
+        guard let index = jobs.firstIndex(where: { $0.id == id }) else { return }
+        if let status = status {
+            jobs[index].status = status
+        }
+        if let progress = progress {
+            jobs[index].progress = progress
+        }
+        if let log = log {
+            jobs[index].logs.append(log)
+        }
+    }
+
+    func openReleasesFolder() {
+        // Placeholder for opening releases folder
+    }
+}

--- a/StoryMakerApp/StoryMakerApp/Models/KeychainHelper.swift
+++ b/StoryMakerApp/StoryMakerApp/Models/KeychainHelper.swift
@@ -1,0 +1,31 @@
+import Foundation
+import Security
+
+class KeychainHelper {
+    static let shared = KeychainHelper()
+
+    func set(key: String, value: String) {
+        let data = value.data(using: .utf8) ?? Data()
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key,
+            kSecValueData as String: data
+        ]
+        SecItemDelete(query as CFDictionary)
+        SecItemAdd(query as CFDictionary, nil)
+    }
+
+    func get(key: String) -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: key,
+            kSecReturnData as String: true
+        ]
+        var result: AnyObject?
+        SecItemCopyMatching(query as CFDictionary, &result)
+        if let data = result as? Data {
+            return String(data: data, encoding: .utf8)
+        }
+        return nil
+    }
+}

--- a/StoryMakerApp/StoryMakerApp/Models/SettingsStore.swift
+++ b/StoryMakerApp/StoryMakerApp/Models/SettingsStore.swift
@@ -1,0 +1,67 @@
+import Foundation
+import SQLite3
+
+class SettingsStore: ObservableObject {
+    private var db: OpaquePointer?
+
+    @Published var enginePath: String = ""
+    @Published var releasesPath: String = "releases"
+    @Published var defaultFPS: Int = 30
+    @Published var apiKey: String = ""
+
+    init() {
+        openDatabase()
+        load()
+    }
+
+    deinit {
+        sqlite3_close(db)
+    }
+
+    private func openDatabase() {
+        let url = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent("settings.sqlite")
+        if sqlite3_open(url.path, &db) != SQLITE_OK {
+            print("Unable to open database")
+        } else {
+            sqlite3_exec(db, "CREATE TABLE IF NOT EXISTS settings(key TEXT PRIMARY KEY, value TEXT)", nil, nil, nil)
+        }
+    }
+
+    func load() {
+        enginePath = get(key: "enginePath") ?? ""
+        releasesPath = get(key: "releasesPath") ?? "releases"
+        defaultFPS = Int(get(key: "defaultFPS") ?? "30") ?? 30
+        apiKey = KeychainHelper.shared.get(key: "openai") ?? ""
+    }
+
+    func save() {
+        set(key: "enginePath", value: enginePath)
+        set(key: "releasesPath", value: releasesPath)
+        set(key: "defaultFPS", value: String(defaultFPS))
+        KeychainHelper.shared.set(key: "openai", value: apiKey)
+    }
+
+    private func get(key: String) -> String? {
+        var stmt: OpaquePointer?
+        if sqlite3_prepare_v2(db, "SELECT value FROM settings WHERE key=?", -1, &stmt, nil) == SQLITE_OK {
+            sqlite3_bind_text(stmt, 1, key, -1, nil)
+            if sqlite3_step(stmt) == SQLITE_ROW, let cString = sqlite3_column_text(stmt, 0) {
+                let value = String(cString: cString)
+                sqlite3_finalize(stmt)
+                return value
+            }
+        }
+        sqlite3_finalize(stmt)
+        return nil
+    }
+
+    private func set(key: String, value: String) {
+        var stmt: OpaquePointer?
+        if sqlite3_prepare_v2(db, "REPLACE INTO settings(key,value) VALUES(?,?)", -1, &stmt, nil) == SQLITE_OK {
+            sqlite3_bind_text(stmt, 1, key, -1, nil)
+            sqlite3_bind_text(stmt, 2, value, -1, nil)
+            sqlite3_step(stmt)
+        }
+        sqlite3_finalize(stmt)
+    }
+}

--- a/StoryMakerApp/StoryMakerApp/PublishView.swift
+++ b/StoryMakerApp/StoryMakerApp/PublishView.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+struct PublishView: View {
+    @State private var publishYouTube: Bool = false
+    @State private var publishDrive: Bool = false
+    @State private var title: String = ""
+    @State private var description: String = ""
+    @State private var tags: String = ""
+
+    var body: some View {
+        Form {
+            Toggle("YouTube (draft)", isOn: $publishYouTube)
+            Toggle("Drive", isOn: $publishDrive)
+            Toggle("Telegram", isOn: .constant(false))
+                .disabled(true)
+            TextField("Title", text: $title)
+            TextField("Description", text: $description)
+            TextField("Tags", text: $tags)
+            Button("Publish", action: publish)
+        }
+        .padding()
+    }
+
+    func publish() {
+        let releases = URL(fileURLWithPath: "releases", relativeTo: URL(fileURLWithPath: FileManager.default.currentDirectoryPath))
+        try? FileManager.default.createDirectory(at: releases, withIntermediateDirectories: true)
+    }
+}

--- a/StoryMakerApp/StoryMakerApp/SettingsView.swift
+++ b/StoryMakerApp/StoryMakerApp/SettingsView.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+struct SettingsView: View {
+    @EnvironmentObject var settings: SettingsStore
+    @State private var enginePath: String = ""
+    @State private var apiKey: String = ""
+    @State private var releasesPath: String = "releases"
+    @State private var defaultFPS: Int = 30
+
+    var body: some View {
+        Form {
+            TextField("Engine Path", text: $enginePath)
+            SecureField("OpenAI API Key", text: $apiKey)
+            TextField("Releases Path", text: $releasesPath)
+            Stepper("Default FPS: \(defaultFPS)", value: $defaultFPS, in: 1...120)
+            Button("Save", action: save)
+        }
+        .padding()
+        .onAppear {
+            enginePath = settings.enginePath
+            releasesPath = settings.releasesPath
+            defaultFPS = settings.defaultFPS
+            apiKey = settings.apiKey
+        }
+    }
+
+    func save() {
+        settings.enginePath = enginePath
+        settings.releasesPath = releasesPath
+        settings.defaultFPS = defaultFPS
+        settings.apiKey = apiKey
+        settings.save()
+    }
+}

--- a/StoryMakerApp/StoryMakerApp/StoryMakerAppApp.swift
+++ b/StoryMakerApp/StoryMakerApp/StoryMakerAppApp.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+@main
+struct StoryMakerAppApp: App {
+    @StateObject private var jobQueue = JobQueue()
+    @StateObject private var settingsStore = SettingsStore()
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .environmentObject(jobQueue)
+                .environmentObject(settingsStore)
+        }
+        .commands {
+            AppCommands(jobQueue: jobQueue)
+        }
+    }
+}

--- a/StoryMakerApp/StoryMakerApp/StoryView.swift
+++ b/StoryMakerApp/StoryMakerApp/StoryView.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+
+struct StoryView: View {
+    @State private var prompt: String = ""
+    @State private var genre: String = ""
+    @State private var targetDuration: Double = 5
+    @State private var scenesMin: Int = 3
+    @State private var scenesMax: Int = 5
+    @State private var preview: String = ""
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            Form {
+                TextEditor(text: $prompt)
+                    .frame(minHeight: 100)
+                    .border(Color.gray)
+                    .padding(.bottom)
+                TextField("Genre", text: $genre)
+                HStack {
+                    Text("Target duration (min)")
+                    Slider(value: $targetDuration, in: 1...20, step: 1)
+                    Text("\(Int(targetDuration))")
+                }
+                HStack {
+                    Stepper("Scenes min: \(scenesMin)", value: $scenesMin, in: 1...20)
+                    Stepper("Scenes max: \(scenesMax)", value: $scenesMax, in: 1...20)
+                }
+                Button("Generate Story JSON", action: generateStory)
+            }
+            if !preview.isEmpty {
+                Text("Preview:")
+                    .font(.headline)
+                ScrollView {
+                    Text(preview)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+        }
+        .padding()
+    }
+
+    func generateStory() {
+        let story = [
+            "prompt": prompt,
+            "genre": genre,
+            "targetDuration": targetDuration,
+            "scenesMin": scenesMin,
+            "scenesMax": scenesMax
+        ] as [String : Any]
+        do {
+            let data = try JSONSerialization.data(withJSONObject: story, options: [.prettyPrinted])
+            let slug = prompt.replacingOccurrences(of: " ", with: "-").lowercased()
+            let url = URL(fileURLWithPath: "stories/\(slug).json", relativeTo: URL(fileURLWithPath: FileManager.default.currentDirectoryPath))
+            try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try data.write(to: url)
+            preview = String(decoding: data, as: UTF8.self)
+        } catch {
+            preview = "Error: \(error.localizedDescription)"
+        }
+    }
+}

--- a/StoryMakerApp/StoryMakerApp/TTSView.swift
+++ b/StoryMakerApp/StoryMakerApp/TTSView.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+struct TTSView: View {
+    @State private var voice: String = "default"
+    @State private var speed: Double = 1.0
+
+    var body: some View {
+        Form {
+            TextField("Voice", text: $voice)
+            HStack {
+                Text("Speed")
+                Slider(value: $speed, in: 0.5...1.5, step: 0.1)
+                Text(String(format: "%.1f", speed))
+            }
+            Button("Render MP3", action: renderAudio)
+        }
+        .padding()
+    }
+
+    func renderAudio() {
+        let buildDir = URL(fileURLWithPath: "build/audio", relativeTo: URL(fileURLWithPath: FileManager.default.currentDirectoryPath))
+        try? FileManager.default.createDirectory(at: buildDir, withIntermediateDirectories: true)
+        let output = buildDir.appendingPathComponent("story.mp3")
+        FileManager.default.createFile(atPath: output.path, contents: Data())
+    }
+}


### PR DESCRIPTION
## Summary
- add StoryMakerApp SwiftUI macOS project with dashboard, story editor, image, TTS, assemble, publish, and settings tabs
- implement in-memory job queue, SQLite-backed settings store, and keychain helper
- wire up macOS menu commands and file IO stubs for story JSON, audio, and video

## Testing
- `swift build` (fails: Could not find Package.swift in this directory or any of its parent directories.)

------
https://chatgpt.com/codex/tasks/task_e_68ae00026888833098f3892d3116cc26