### PR TITLE
feat: add release management and scheduling stubs

### DIFF
--- a/integrations.py
+++ b/integrations.py
@@ -1,0 +1,26 @@
+"""Place-holder integrations for future uploads."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict
+
+
+@dataclass
+class IntegrationBase:
+    enabled: bool = False
+    oauth: Dict[str, str] = field(default_factory=dict)
+
+    def run(self, *_, **__):  # pragma: no cover - placeholder
+        raise RuntimeError("Integration disabled")
+
+
+class YouTubeUpload(IntegrationBase):
+    pass
+
+
+class DriveUpload(IntegrationBase):
+    pass
+
+
+class TelegramIntegration(IntegrationBase):
+    pass

--- a/notifications.py
+++ b/notifications.py
@@ -1,0 +1,16 @@
+"""Simple wrapper around macOS notifications."""
+from __future__ import annotations
+
+import subprocess
+
+
+def notify(title: str, message: str) -> None:
+    """Send a user notification on macOS.
+
+    Falls back to printing when notification utilities are unavailable."""
+    script = f'display notification "{message}" with title "{title}"'
+    try:
+        subprocess.run(["osascript", "-e", script], check=True)
+    except Exception:
+        # Fallback for non-macOS environments
+        print(f"{title}: {message}")

--- a/release.py
+++ b/release.py
@@ -1,0 +1,96 @@
+"""Utilities to manage release artifacts for generated videos."""
+from __future__ import annotations
+
+import os
+import pathlib
+import shutil
+import subprocess
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+
+@dataclass
+class ReleaseInfo:
+    """Metadata about a generated release."""
+
+    slug: str
+    path: pathlib.Path
+    status: str
+
+
+class ReleaseManager:
+    """Create folders with artifacts of generated stories."""
+
+    def __init__(self, base_dir: str = "releases") -> None:
+        self.base_dir = pathlib.Path(base_dir)
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+
+    def create_release(
+        self,
+        story_path: str,
+        images_dir: Optional[str],
+        audio_path: Optional[str],
+        video_path: Optional[str],
+        scenes: int,
+        audio_duration: float,
+        status: str,
+    ) -> ReleaseInfo:
+        slug = datetime.now().strftime("%Y%m%d_%H%M%S")
+        target = self.base_dir / slug
+        target.mkdir(parents=True, exist_ok=True)
+
+        # Copy story
+        if story_path and os.path.exists(story_path):
+            shutil.copy(story_path, target / "story.json")
+
+        # Copy images directory
+        if images_dir and os.path.isdir(images_dir):
+            shutil.copytree(images_dir, target / "images")
+
+        # Copy/convert audio
+        if audio_path and os.path.exists(audio_path):
+            audio_out = target / "audio.mp3"
+            self._convert_to_mp3(audio_path, audio_out)
+
+        # Copy video
+        if video_path and os.path.exists(video_path):
+            shutil.copy(video_path, target / "video.mp4")
+
+        # Write report
+        report = target / "report.md"
+        with open(report, "w", encoding="utf-8") as fh:
+            fh.write("# Release report\n\n")
+            fh.write(f"Date: {datetime.now().isoformat()}\n")
+            fh.write(f"Scenes: {scenes}\n")
+            fh.write(f"Audio duration: {audio_duration:.2f} sec\n")
+            if story_path:
+                fh.write(f"Story: {target / 'story.json'}\n")
+            if images_dir:
+                fh.write(f"Images: {target / 'images'}\n")
+            if audio_path:
+                fh.write(f"Audio: {target / 'audio.mp3'}\n")
+            if video_path:
+                fh.write(f"Video: {target / 'video.mp4'}\n")
+            fh.write(f"Status: {status}\n")
+
+        return ReleaseInfo(slug=slug, path=target, status=status)
+
+    def open_in_finder(self, release_path: str) -> None:
+        """Open the given release directory in Finder (macOS)."""
+        try:
+            subprocess.run(["open", release_path], check=True)
+        except Exception:
+            pass
+
+    def _convert_to_mp3(self, src: str, dst: pathlib.Path) -> None:
+        try:
+            subprocess.run(
+                ["ffmpeg", "-y", "-i", src, dst],
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        except Exception:
+            # Fallback to just copying if ffmpeg is unavailable
+            shutil.copy(src, dst.with_suffix(".wav"))

--- a/run.py
+++ b/run.py
@@ -5,42 +5,76 @@ from images_comfy import generate_images
 from utils_audio import mix_music
 from subtitles import srt_from_chunks
 from assemble_video import assemble
+from notifications import notify
+from release import ReleaseManager
 
 def main(story_path, out_dir):
     pathlib.Path(out_dir).mkdir(parents=True, exist_ok=True)
+    release_mgr = ReleaseManager()
     story = json.load(open(story_path, "r", encoding="utf-8"))
     beats = story["beats"]
-    # 1) TTS per beat -> wavs + concat list
-    chunks = []
-    for i, b in enumerate(beats, 1):
-        wav = os.path.join(out_dir, f"audio_beat{i}.wav")
-        synthesize(b["narration_text"], wav)
-        chunks.append({"text": b["narration_text"], "wav_path": wav})
-    # 2) Concatenate beats with 500ms silence
-    from pydub import AudioSegment
-    narration_all = AudioSegment.silent(duration=0)
-    for ch in chunks:
-        narration_all += AudioSegment.from_file(ch["wav_path"]) + AudioSegment.silent(duration=500)
-    final_narration = os.path.join(out_dir, "narration_full.wav")
-    narration_all.export(final_narration, format="wav")
-    # 3) Images from prompts
-    prompts = [b["image_prompt"] for b in beats]
-    slides = generate_images(prompts, os.path.join(out_dir, "slides"), images_per_prompt=story.get("images_per_beat", 1))
-    # 4) Optional music
-    music_files = []
-    for ext in ("*.mp3","*.wav","*.flac","*.m4a","*.ogg"):
-        music_files += glob.glob(os.path.join(MUSIC_DIR, ext))
-    music_mix = final_narration
-    if story.get("music_policy",{}).get("use_music") and music_files:
-        music_mix = os.path.join(out_dir, "narration_with_music.wav")
-        mix_music(final_narration, music_files[0], music_mix, duck_db=story.get("music_policy",{}).get("ducking_db",-12.0))
-    # 5) Subtitles
-    srt_path = os.path.join(out_dir, "subtitles.srt")
-    srt_from_chunks(chunks, srt_path)
-    # 6) Assemble video
-    mp4 = os.path.join(out_dir, "final_1080p.mp4")
-    assemble(slides if slides else ["./assets/fallback.jpg"], music_mix, mp4)
-    print("DONE:", mp4)
+    status = "success"
+    try:
+        # 1) TTS per beat -> wavs + concat list
+        chunks = []
+        for i, b in enumerate(beats, 1):
+            wav = os.path.join(out_dir, f"audio_beat{i}.wav")
+            synthesize(b["narration_text"], wav)
+            chunks.append({"text": b["narration_text"], "wav_path": wav})
+        # 2) Concatenate beats with 500ms silence
+        from pydub import AudioSegment
+        narration_all = AudioSegment.silent(duration=0)
+        for ch in chunks:
+            narration_all += AudioSegment.from_file(ch["wav_path"]) + AudioSegment.silent(duration=500)
+        final_narration = os.path.join(out_dir, "narration_full.wav")
+        narration_all.export(final_narration, format="wav")
+        # 3) Images from prompts
+        prompts = [b["image_prompt"] for b in beats]
+        slides_dir = os.path.join(out_dir, "slides")
+        slides = generate_images(prompts, slides_dir, images_per_prompt=story.get("images_per_beat", 1))
+        # 4) Optional music
+        music_files = []
+        for ext in ("*.mp3","*.wav","*.flac","*.m4a","*.ogg"):
+            music_files += glob.glob(os.path.join(MUSIC_DIR, ext))
+        music_mix = final_narration
+        if story.get("music_policy",{}).get("use_music") and music_files:
+            music_mix = os.path.join(out_dir, "narration_with_music.wav")
+            mix_music(final_narration, music_files[0], music_mix, duck_db=story.get("music_policy",{}).get("ducking_db",-12.0))
+        # 5) Subtitles
+        srt_path = os.path.join(out_dir, "subtitles.srt")
+        srt_from_chunks(chunks, srt_path)
+        # 6) Assemble video
+        mp4 = os.path.join(out_dir, "final_1080p.mp4")
+        assemble(slides if slides else ["./assets/fallback.jpg"], music_mix, mp4)
+        print("DONE:", mp4)
+        # 7) Release artifacts
+        release_info = release_mgr.create_release(
+            story_path,
+            slides_dir,
+            music_mix,
+            mp4,
+            len(beats),
+            len(narration_all) / 1000,
+            status,
+        )
+        notify("Pipeline complete", f"Release saved to {release_info.path}")
+    except Exception as exc:
+        status = f"error: {exc}"
+        notify("Pipeline failed", str(exc))
+        # Attempt to write failing report
+        try:
+            release_mgr.create_release(
+                story_path,
+                os.path.join(out_dir, "slides"),
+                locals().get("music_mix"),
+                locals().get("mp4"),
+                len(beats),
+                len(locals().get("narration_all", [])) / 1000 if "narration_all" in locals() else 0.0,
+                status,
+            )
+        except Exception:
+            pass
+        raise
 
 if __name__ == "__main__":
     ap = argparse.ArgumentParser()

--- a/scheduler.py
+++ b/scheduler.py
@@ -1,0 +1,80 @@
+"""Launchd-based scheduling utilities."""
+from __future__ import annotations
+
+import os
+import pathlib
+import plistlib
+import subprocess
+from dataclasses import dataclass, field
+from typing import List
+
+LAUNCH_AGENTS = pathlib.Path.home() / "Library" / "LaunchAgents"
+BUNDLE_PREFIX = "com.storymaker"
+
+
+@dataclass
+class ScheduleRule:
+    profile_id: str
+    time: str  # HH:MM
+    days: List[str] = field(default_factory=lambda: ["*"])
+    enabled: bool = True
+
+    @property
+    def plist_path(self) -> pathlib.Path:
+        return LAUNCH_AGENTS / f"{BUNDLE_PREFIX}.{self.profile_id}.plist"
+
+
+DAY_MAP = {
+    "mon": 1,
+    "tue": 2,
+    "wed": 3,
+    "thu": 4,
+    "fri": 5,
+    "sat": 6,
+    "sun": 0,
+}
+
+
+def _day_to_int(day: str) -> int:
+    return DAY_MAP.get(day.lower(), -1)
+
+
+def install_rule(rule: ScheduleRule) -> None:
+    """Create and load a launchd plist for the rule."""
+    LAUNCH_AGENTS.mkdir(parents=True, exist_ok=True)
+    hour, minute = [int(x) for x in rule.time.split(":", 1)]
+    interval = {"Hour": hour, "Minute": minute}
+    weekdays = [_day_to_int(d) for d in rule.days if d != "*"]
+    if weekdays:
+        interval["Weekday"] = weekdays
+    plist = {
+        "Label": f"{BUNDLE_PREFIX}.{rule.profile_id}",
+        "ProgramArguments": ["/usr/local/bin/storymaker", f"--run-pipeline={rule.profile_id}"],
+        "StartCalendarInterval": interval,
+    }
+    with open(rule.plist_path, "wb") as fh:
+        plistlib.dump(plist, fh)
+    if rule.enabled:
+        try:
+            subprocess.run(["launchctl", "load", str(rule.plist_path)], check=True)
+        except Exception:
+            pass
+
+
+def remove_rule(profile_id: str) -> None:
+    plist = LAUNCH_AGENTS / f"{BUNDLE_PREFIX}.{profile_id}.plist"
+    if plist.exists():
+        try:
+            subprocess.run(["launchctl", "unload", str(plist)], check=True)
+        except Exception:
+            pass
+        plist.unlink()
+
+
+def run_now(profile_id: str) -> None:
+    """Run the pipeline immediately for the given profile."""
+    try:
+        subprocess.run(["launchctl", "start", f"{BUNDLE_PREFIX}.{profile_id}"], check=True)
+    except Exception:
+        # Fallback to running the binary directly
+        subprocess.run(["/usr/local/bin/storymaker", f"--run-pipeline={profile_id}"])


### PR DESCRIPTION
## Summary
- integrate release folder creation and basic macOS notifications into pipeline
- add launchd-based scheduling helpers
- scaffold placeholders for future upload integrations

## Testing
- `python -m py_compile run.py release.py notifications.py scheduler.py integrations.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae034cfd1083308a44b32c4e66382c